### PR TITLE
Add type file and missing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+npm-debug.log
+.c9
+node_modules/
+yarn.*

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://cd.smartface.io/repository/smartfacenpmpublic
+email=info@smartface.io
+always-auth=true

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ const spriteView = new SpriteView();
 
 spriteView.setSprite({
 	sheet: Image.createFromFile("images://braid.png"), // Image for the frame
-	frameX: 7, // X Position of the window
-	frameY: 4, // X Position of the window
+	frameX: 7, // Distinct image count on X axis
+	frameY: 4, // Distinct image count on Y axis
 	frameCount: 27 // Frame count of the image
 });
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import SpriteView from "sf-extension-spriteview";
 const spriteView = new SpriteView();
 
 spriteView.setSprite({
-    sheet: Image.createFromFile("images://braid.png"), // Image for the frame
+	sheet: Image.createFromFile("images://braid.png"), // Image for the frame
 	frameX: 7, // X Position of the window
 	frameY: 4, // X Position of the window
 	frameCount: 27 // Frame count of the image

--- a/README.md
+++ b/README.md
@@ -18,16 +18,28 @@ SpriteView is nothing but an [ImageView](http://ref.smartface.io/#!/api/UI.Image
 1) Put the sprite sheet under the folder `images` on the Cloud IDE. 
 2) Set the sheet to the SpriteView object as:
 ```javascript
-spriteObject.setSprite({
-	sheet: Image.createFromFile("images://spritesheet.png"),
-	frameX: << #frames in axis-X >>, // Number
-	frameY: << #frames in axis-Y >>, // Number
-	frameCount: << #frames in the sheet >> // Number
+import SpriteView from "sf-extension-spriteview";
+
+const spriteView = new SpriteView();
+
+spriteView.setSprite({
+    sheet: Image.createFromFile("images://braid.png"), // Image for the frame
+	frameX: 7, // X Position of the window
+	frameY: 4, // X Position of the window
+	frameCount: 27 // Frame count of the image
 });
 ```
-3) Finally you must make the sprite play by using:
+3) Set the optional fields to the SpriteView as:
+````javascript
+import ImageView from "sf-core/ui/imageview";
+
+spriteView.width = 100; // Width of the frame
+spriteView.height = 125; // Height of the frame
+spriteView.imageFillType = ImageView.FillType.ASPECTFIT; // Fill type of the frame
+````
+4) Finally you must make the sprite play by using:
 ```javascript
-spriteObject.play(<< loop duration in ms >>); // Number
+spriteView.play(1000); // Transition speed of frames
 ```
 
 ## Sample

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,15 +12,15 @@ declare interface ISpriteViewOptions {
     /**
      * Width of the frame
      */
-    width: number;
+    width?: number;
     /**
      * Height of the frame
      */
-    height: number;
+    height?: number;
     /**
      * Fill type of the frame
      */
-    imageFillType: ImageView.FillType;
+    imageFillType?: ImageView.FillType;
 }
 
 export type SetSpriteOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,11 +29,13 @@ export type SetSpriteOptions = {
      */
     sheet: Image,
     /**
-     * X Position of the window
+     * Frame X count
+     * Distinct image count on X axis
      */
     frameX: number,
     /**
-     * Y Position of the window
+     * Frame Y count
+     * Distinct image count on Y axis
      */
     frameY: number,
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,22 @@ export type SetSpriteOptions = {
  * });
  */
 export default class {
+
+    /**
+     * Width of the frame
+     */
+    width: number;
+
+    /**
+     * Height of the frame
+     */
+    height: number;
+
+    /**
+     * Fill type of the frame
+     */
+    imageFillType: ImageView.FillType;
+
     /**
      * @class
      * @author Berk Baski <berk.baski@smartface.io>
@@ -71,7 +87,7 @@ export default class {
      *     imageFillType: ImageView.FillType.ASPECTFIT
      * });
      */
-    constructor(options: ISpriteViewOptions);
+    constructor(options?: ISpriteViewOptions);
 
     /**
      * Prepares the frame with the given value.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,114 @@
+/**
+ * SpriteView utility
+ * @type {object}
+ * @author Berk Baski <berk.baski@smartface.io>
+ * @copyright Smartface 2021
+ */
+
+import ImageView from "sf-core/ui/imageview";
+import Image from "sf-core/ui/image";
+
+declare interface ISpriteViewOptions {
+    /**
+     * Width of the frame
+     */
+    width: number;
+    /**
+     * Height of the frame
+     */
+    height: number;
+    /**
+     * Fill type of the frame
+     */
+    imageFillType: ImageView.FillType;
+}
+
+export type SetSpriteOptions = {
+    /**
+     * Image for the frame
+     */
+    sheet: Image,
+    /**
+     * X Position of the window
+     */
+    frameX: number,
+    /**
+     * Y Position of the window
+     */
+    frameY: number,
+    /**
+     * Frame count of the image
+     */
+    frameCount: number
+}
+
+/**
+ * @class
+ * @author Berk Baski <berk.baski@smartface.io>
+ * @copyright Smartface 2021
+ * @example
+ * import SpriteView from "sf-extension-spriteview";
+ * import ImageView from "sf-core/ui/imageview";
+ * 
+ * const spriteView = new SpriteView({
+ *     width: 150,
+ *     height: 200,
+ *     imageFillType: ImageView.FillType.ASPECTFIT
+ * });
+ */
+export default class {
+    /**
+     * @class
+     * @author Berk Baski <berk.baski@smartface.io>
+     * @copyright Smartface 2021
+     * @example
+     * import SpriteView from "sf-extension-spriteview";
+     * import ImageView from "sf-core/ui/imageview";
+     * 
+     * const spriteView = new SpriteView({
+     *     width: 150,
+     *     height: 200,
+     *     imageFillType: ImageView.FillType.ASPECTFIT
+     * });
+     */
+    constructor(options: ISpriteViewOptions);
+
+    /**
+     * Prepares the frame with the given value.
+     * @function setSprite
+     * @param {SetSpriteOptions} params
+     * @example
+     * spriteView.setSprite({
+     *      sheet: Image.createFromFile("images://braid.png"),
+     *      frameX: 7,
+     *      frameY: 4,
+     *      frameCount: 27
+     *});
+     */
+    setSprite(params: SetSpriteOptions): void;
+
+    /**
+     * Starts the animation according to the given `duration` value.
+     * @function play
+     * @param {number} duration Transition speed of frames
+     * @example
+     * spriteView.play(1000);
+     */
+    play(duration: number): void;
+
+    /**
+     * Goes to the next frame.
+     * @function showNextFrame
+     * @example
+     * spriteView.showNextFrame();
+     */
+    showNextFrame(): void;
+
+    /**
+     * Stops animation.
+     * @function stop
+     * @example
+     * spriteView.stop();
+     */
+    stop(): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,9 +39,9 @@ export type SetSpriteOptions = {
      */
     frameY: number,
     /**
-     * Frame count of the image
+     * Frame count of the image. If no value is given, it takes the multiply frameX by frameY value.
      */
-    frameCount: number
+    frameCount?: number
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,59 +1,58 @@
 const extend = require("js-base/core/extend");
 
-const Timer     = require("sf-core/timer");
+const Timer = require("sf-core/timer");
 const ImageView = require("sf-core/ui/imageview");
 
 const SpriteView = extend(ImageView)(
-    function(_super,params)
-    {
+    function (_super, params) {
         _super(this, params);
-        
+
         this._currentFrame = 0;
         this._frameCount = 0;
         this._frames = [];
         this._timer = null;
-        
-        this.setSprite = function(params) {
+
+        this.setSprite = function (params) {
             this._frames = [];
-            this._frameCount = params["frameCount"];
-            
-            var frameWidth  = params["sheet"].width  / params["frameX"];
-            var frameHeight = params["sheet"].height / params["frameY"];
+            this._frameCount = params["frameCount"] || params["frameX"] * params["frameY"];
+            this._frameWidth = params["sheet"].width / params["frameX"];
+            this._frameHeight = params["sheet"].height / params["frameY"];
+
             for (var currentY = 0; currentY < params["frameY"]; currentY++) {
                 for (var currentX = 0; currentX < params["frameX"] && (currentX + currentY) < this._frameCount; currentX++) {
                     params["sheet"].crop(
-                        currentX * frameWidth,
-                        currentY * frameHeight,
-                        frameWidth,
-                        frameHeight,
-                        function(e) {
+                        currentX * this._frameWidth,
+                        currentY * this._frameHeight,
+                        this._frameWidth,
+                        this._frameHeight,
+                        function (e) {
                             this._frames.push(e.image);
                         }.bind(this),
-                        function() {
+                        function () {
                             console.log("failed to parse sheet.");
                         }.bind(this)
                     );
                 }
             }
         };
-        
-        this.play = function(duration) {
+
+        this.play = function (duration) {
             var frameDuration = duration / this._frameCount;
 
             this._timer = Timer.setInterval({
                 delay: frameDuration,
-                task: function() {
+                task: function () {
                     this.showNextFrame();
                 }.bind(this)
             });
         };
 
-        this.showNextFrame = function() {
+        this.showNextFrame = function () {
             this._currentFrame = (this._currentFrame + 1) % this._frameCount;
             this.image = this._frames[this._currentFrame];
         };
-        
-        this.stop = function() {
+
+        this.stop = function () {
             if (this._timer) {
                 Timer.clearTimer(this._timer);
             }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "peerDependencies": {
+    "sf-core": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Hey!

I want to do two more fixes.

### 1. Updating the JavaScript samples in the README.md file to TypeScript.
In the examples on the README.md file, the types are given as characters and comment lines. I don't know how to update this.

Like this
```javascript
spriteObject.setSprite({
	sheet: Image.createFromFile("images://spritesheet.png"),
	frameX: << #frames in axis-X >>, // Number
	frameY: << #frames in axis-Y >>, // Number
	frameCount: << #frames in the sheet >> // Number
});
```

### 2. I want to make the parameter in the constructor optional if necessary. 
But I think incoming parameters pass to the Image object. I wasn't sure if I should do this.

I have time for suggestions.